### PR TITLE
Restructure site into separate pages and add navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.claude/
+.next/

--- a/components/experience.js
+++ b/components/experience.js
@@ -61,7 +61,7 @@ function ExperienceTile({ isExperience, experience }) {
                     <h5>{experience.title}</h5>
                 </Row>
                 <Row className="mb-2 text-muted">
-                    {experience.start} - {experience.end}
+                    {experience.start}{experience.end ? ` - ${experience.end}` : ''}
                 </Row>
                 <Row className="mb-2 text-muted">
                     {experience.location}
@@ -92,11 +92,13 @@ function ExperienceTile({ isExperience, experience }) {
                 </Row>
             </Col>
             <Col className="d-flex justify-content-center flex-column">
-                <ul>
-                    {experience.description.split('. ').filter(point => point.trim() !== '').slice(0, 2).map((point, index) => (
-                        <li key={index}>{point}</li>
-                    ))}
-                </ul>
+                {experience.description && (
+                    <ul>
+                        {experience.description.split('. ').filter(point => point.trim() !== '').slice(0, 2).map((point, index) => (
+                            <li key={index}>{point}</li>
+                        ))}
+                    </ul>
+                )}
             </Col>
         </Row>
     );

--- a/components/topbar.js
+++ b/components/topbar.js
@@ -2,9 +2,11 @@
 
 import { Container, Navbar, Nav, Offcanvas, ButtonGroup, ToggleButton } from "react-bootstrap";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 export default function Topbar() {
+    const router = useRouter();
     const [show, setShow] = useState(false);
     const [visible, setVisible] = useState(false);
     const pageYOffsetTrigger = 150;
@@ -136,13 +138,74 @@ export default function Topbar() {
                         </Offcanvas.Header>
                         <Offcanvas.Body>
                             <Nav className="justify-content-end flex-grow-1 pe-3">
-                                <Nav.Link href="/" as={Link} className="main-text-regular" onClick={() => setShow(false)}>
+                                <Nav.Link
+                                    href="/"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/'}
+                                    aria-current={router.pathname === '/' ? 'page' : undefined}
+                                >
                                     Home
                                 </Nav.Link>
-                                <Nav.Link href="/about" as={Link} className="main-text-regular" onClick={() => setShow(false)}>
+                                <Nav.Link
+                                    href="/education"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/education'}
+                                    aria-current={router.pathname === '/education' ? 'page' : undefined}
+                                >
+                                    Education
+                                </Nav.Link>
+                                <Nav.Link
+                                    href="/work-experience"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/work-experience'}
+                                    aria-current={router.pathname === '/work-experience' ? 'page' : undefined}
+                                >
+                                    Work Experience
+                                </Nav.Link>
+                                <Nav.Link
+                                    href="/publications"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/publications'}
+                                    aria-current={router.pathname === '/publications' ? 'page' : undefined}
+                                >
+                                    Publications
+                                </Nav.Link>
+                                <Nav.Link
+                                    href="/awards"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/awards'}
+                                    aria-current={router.pathname === '/awards' ? 'page' : undefined}
+                                >
+                                    Awards
+                                </Nav.Link>
+                                <Nav.Link
+                                    href="/about"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/about'}
+                                    aria-current={router.pathname === '/about' ? 'page' : undefined}
+                                >
                                     About
                                 </Nav.Link>
-                                <Nav.Link href="/contact" as={Link} className="main-text-regular" onClick={() => setShow(false)}>
+                                <Nav.Link
+                                    href="/contact"
+                                    as={Link}
+                                    className="main-text-regular"
+                                    onClick={() => setShow(false)}
+                                    active={router.pathname === '/contact'}
+                                    aria-current={router.pathname === '/contact' ? 'page' : undefined}
+                                >
                                     Contact Me
                                 </Nav.Link>
                             </Nav>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "my-website",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "windev": "next dev",
     "dev": "LAST_UPDATED=$(date) next dev",

--- a/pages/awards.js
+++ b/pages/awards.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Head from 'next/head';
+import Container from 'react-bootstrap/Container';
+import { Row } from 'react-bootstrap';
+import Experience from '@/components/experience';
+import awards from '/public/jsons/awards.json';
+
+export default function AwardsPage() {
+  return (
+    <>
+      <Head>
+        <title>Awards | Aryan Sharma</title>
+        <meta
+          name="description"
+          content="Awards and recognitions received by Aryan Sharma for academic excellence and professional achievements."
+        />
+        <meta property="og:title" content="Awards | Aryan Sharma" />
+        <meta
+          property="og:description"
+          content="Awards and recognitions received by Aryan Sharma for academic excellence and professional achievements."
+        />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Awards | Aryan Sharma" />
+        <meta
+          name="twitter:description"
+          content="Awards and recognitions received by Aryan Sharma for academic excellence and professional achievements."
+        />
+      </Head>
+      <Container className="home">
+        <main>
+          <Row>
+            <Experience jsonExperiences={awards} title="Awards" isExperience={false} />
+          </Row>
+        </main>
+      </Container>
+    </>
+  );
+}

--- a/pages/education.js
+++ b/pages/education.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import Head from 'next/head';
+import Container from 'react-bootstrap/Container';
+import Education from '@/components/education';
+
+export default function EducationPage() {
+  return (
+    <>
+      <Head>
+        <title>Education | Aryan Sharma</title>
+        <meta
+          name="description"
+          content="Educational background of Aryan Sharma, including degrees from University of Michigan and other institutions."
+        />
+        <meta property="og:title" content="Education | Aryan Sharma" />
+        <meta
+          property="og:description"
+          content="Educational background of Aryan Sharma, including degrees from University of Michigan and other institutions."
+        />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Education | Aryan Sharma" />
+        <meta
+          name="twitter:description"
+          content="Educational background of Aryan Sharma, including degrees from University of Michigan and other institutions."
+        />
+      </Head>
+      <Container className="home">
+        <main>
+          <Education />
+        </main>
+      </Container>
+    </>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,110 +1,14 @@
 import React from 'react';
-import { Row, Col } from "react-bootstrap";
-import Experience from "@/components/experience";
-import Containter from "react-bootstrap/Container";
+import { Row } from "react-bootstrap";
+import Container from "react-bootstrap/Container";
 import Hello from '@/components/hello';
-import workExperience from "/public/jsons/work-experience.json";
-// import projects from "/public/jsons/projects.json";
-import awards from "/public/jsons/awards.json";
-import Publication from '@/components/publication';
-import Education from '@/components/education';
-import Link from 'next/link';
-import { useRef, useEffect } from 'react';
-import { gsap } from 'gsap';
-import { ScrollTrigger } from 'gsap/dist/ScrollTrigger';
-gsap.registerPlugin(ScrollTrigger);
 
 export default function Home() {
-  useEffect(() => {
-    const headings = document.querySelectorAll('.content h1');
-    headings.forEach((heading) => {
-      gsap.from(heading, {
-        y: 24,
-        opacity: 0,
-        duration: 0.8,
-        stagger: { amount: 1 },
-        ease: 'ease',
-        scrollTrigger: {
-          trigger: heading,
-          start: 'top 80%',
-        },
-      });
-    });
-  }, []);
   return (
-    <Containter className='home'>
+    <Container className='home'>
       <Row>
         <Hello />
       </Row>
-      <div className="content">
-        <Row>
-          <Education />
-        </Row>
-        <Row>
-          <Experience jsonExperiences={workExperience} title={"Work Experience"} isExperience />
-        </Row>
-        {/* <Row>
-          <Experience jsonExperiences={projects} title={"Projects"} />
-        </Row> */}
-        <Row>
-          <div className="mt-5">
-            <h1 className="mb-3" id="publications">
-              Publications
-            </h1>
-            <Publication />
-          </div>
-        </Row>
-        <Row>
-          <div className="mt-5">
-            <h1 className="mb-3" id="awards">
-              Awards
-            </h1>
-            {
-              awards.map((award, index) => {
-                return (
-                  <Award key={index} award={award} />
-                )
-              })
-            }
-          </div>
-        </Row>
-      </div>
-    </Containter>
+    </Container>
   );
-}
-
-function Award({ award }) {
-  const ref = useRef(null);
-  useEffect(() => {
-    gsap.from(ref.current, {
-      y: 24,
-      opacity: 0,
-      duration: 0.8,
-      ease: 'ease',
-      scrollTrigger: {
-        trigger: ref.current,
-        start: 'top 80%',
-      },
-    });
-  }, []);
-  return (
-    <Row className="mb-3" ref={ref}>
-      <Col xs={1} className="d-flex align-items-center" style={{ width: 'auto' }}>
-        <svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" class="bi bi-trophy-fill" viewBox="0 0 16 16">
-          <path d="M2.5.5A.5.5 0 0 1 3 0h10a.5.5 0 0 1 .5.5c0 .538-.012 1.05-.034 1.536a3 3 0 1 1-1.133 5.89c-.79 1.865-1.878 2.777-2.833 3.011v2.173l1.425.356c.194.048.377.135.537.255L13.3 15.1a.5.5 0 0 1-.3.9H3a.5.5 0 0 1-.3-.9l1.838-1.379c.16-.12.343-.207.537-.255L6.5 13.11v-2.173c-.955-.234-2.043-1.146-2.833-3.012a3 3 0 1 1-1.132-5.89A33.076 33.076 0 0 1 2.5.5zm.099 2.54a2 2 0 0 0 .72 3.935c-.333-1.05-.588-2.346-.72-3.935zm10.083 3.935a2 2 0 0 0 .72-3.935c-.133 1.59-.388 2.885-.72 3.935z" />
-        </svg>
-      </Col>
-      <Col>
-        <div >
-          <h3>{award.title}</h3>
-          <p>
-            {award.link ? <Link href={award.link}>{award.position}</Link> :
-              award.position
-            }
-          </p>
-          <span>{award.date}</span>
-        </div>
-      </Col>
-    </Row>
-  )
 }

--- a/pages/publications.js
+++ b/pages/publications.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import Head from 'next/head';
+import Container from 'react-bootstrap/Container';
+import Publication from '@/components/publication';
+
+export default function PublicationsPage() {
+  return (
+    <>
+      <Head>
+        <title>Publications | Aryan Sharma</title>
+        <meta
+          name="description"
+          content="Research publications and academic work by Aryan Sharma in data science, machine learning, and related fields."
+        />
+        <meta property="og:title" content="Publications | Aryan Sharma" />
+        <meta
+          property="og:description"
+          content="Research publications and academic work by Aryan Sharma in data science, machine learning, and related fields."
+        />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Publications | Aryan Sharma" />
+        <meta
+          name="twitter:description"
+          content="Research publications and academic work by Aryan Sharma in data science, machine learning, and related fields."
+        />
+      </Head>
+      <Container className="home">
+        <main>
+          <div className="mt-5">
+            <h1>Publications</h1>
+            <Publication />
+          </div>
+        </main>
+      </Container>
+    </>
+  );
+}

--- a/pages/work-experience.js
+++ b/pages/work-experience.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Head from 'next/head';
+import Container from 'react-bootstrap/Container';
+import { Row } from 'react-bootstrap';
+import Experience from '@/components/experience';
+import workExperience from '/public/jsons/work-experience.json';
+
+export default function WorkExperiencePage() {
+  return (
+    <>
+      <Head>
+        <title>Work Experience | Aryan Sharma</title>
+        <meta
+          name="description"
+          content="Professional work experience of Aryan Sharma, including roles at Amazon, Genpact, and other organizations."
+        />
+        <meta property="og:title" content="Work Experience | Aryan Sharma" />
+        <meta
+          property="og:description"
+          content="Professional work experience of Aryan Sharma, including roles at Amazon, Genpact, and other organizations."
+        />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Work Experience | Aryan Sharma" />
+        <meta
+          name="twitter:description"
+          content="Professional work experience of Aryan Sharma, including roles at Amazon, Genpact, and other organizations."
+        />
+      </Head>
+      <Container className="home">
+        <main>
+          <Row>
+            <Experience jsonExperiences={workExperience} title="Work Experience" isExperience />
+          </Row>
+        </main>
+      </Container>
+    </>
+  );
+}

--- a/public/jsons/awards.json
+++ b/public/jsons/awards.json
@@ -1,12 +1,16 @@
 [
     {
         "title": "Prof. M R Doreswamy Merit Scholarship for excellent academic performance.",
-        "position": "Top 5% of the class",
-        "date": "2021"
+        "organization": "Top 5% of the class",
+        "start": "2021",
+        "end": "",
+        "image": "/images/trophy.png"
     },
     {
         "title": "Prof. M R Doreswamy Merit Scholarship for excellent academic performance.",
-        "position": "Top 5% of the class",
-        "date": "2020"
+        "organization": "Top 5% of the class",
+        "start": "2020",
+        "end": "",
+        "image": "/images/trophy.png"
     }
 ]

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -259,6 +259,10 @@ html[data-bs-theme="dark"] .bi-trophy-fill {
   fill: #f2f2f2;
 }
 
+html[data-bs-theme="dark"] img[srcset*="trophy.png"] {
+  filter: invert(1);
+}
+
 html[data-bs-theme="dark"] .search-form input:focus+#search-icon {
   background-color: hsl(210, 11%, 20%)
 }


### PR DESCRIPTION
- Add .gitignore for node_modules, .claude, and .next directories
- Create dedicated pages for education, work experience, publications, and awards
- Update topbar navigation with router integration and active page indicators
- Simplify home page to display only hello component
- Update experience component to handle optional date end and description fields
- Restructure awards data with organization, start, end, and image fields
- Add dark theme support for trophy images